### PR TITLE
Generalized 'List', replaced with 'Traversable'

### DIFF
--- a/src/main/scala/anorm/ToStatement.scala
+++ b/src/main/scala/anorm/ToStatement.scala
@@ -6,6 +6,7 @@ private[anorm] trait ProductToStatement {
   import shapeless.ops.hlist.{ LeftFolder, Length }
   import shapeless.ops.nat.ToInt
   import java.sql.PreparedStatement
+  import scala.collection.immutable.SortedSet
 
   private implicit val hNilToStatement: ToStatement[HNil] =
     new ToStatement[HNil] with NotNullGuard {
@@ -29,8 +30,38 @@ private[anorm] trait ProductToStatement {
   implicit def productListToStatement[P <: Product, H <: HList, N <: Nat](
     implicit c: ToStatement[P], generic: Generic.Aux[P, H],
     length: Length.Aux[H, N], toInt: ToInt[N]): ToStatement[List[P]] =
-    new ToStatement[List[P]] with NotNullGuard {
-      def set(s: PreparedStatement, offset: Int, ps: List[P]) =
+    productTraversableToStatement[P, H, N, List[P]]
+
+  implicit def productSeqToStatement[P <: Product, H <: HList, N <: Nat](
+    implicit c: ToStatement[P], generic: Generic.Aux[P, H],
+    length: Length.Aux[H, N], toInt: ToInt[N]): ToStatement[Seq[P]] =
+    productTraversableToStatement[P, H, N, Seq[P]]
+
+  implicit def productSetToStatement[P <: Product, H <: HList, N <: Nat](
+    implicit c: ToStatement[P], generic: Generic.Aux[P, H],
+    length: Length.Aux[H, N], toInt: ToInt[N]): ToStatement[Set[P]] =
+    productTraversableToStatement[P, H, N, Set[P]]
+
+  implicit def productSortedSetToStatement[P <: Product, H <: HList, N <: Nat](
+    implicit c: ToStatement[P], generic: Generic.Aux[P, H],
+    length: Length.Aux[H, N], toInt: ToInt[N]): ToStatement[SortedSet[P]] =
+    productTraversableToStatement[P, H, N, SortedSet[P]]
+
+  implicit def productStreamToStatement[P <: Product, H <: HList, N <: Nat](
+    implicit c: ToStatement[P], generic: Generic.Aux[P, H],
+    length: Length.Aux[H, N], toInt: ToInt[N]): ToStatement[Stream[P]] =
+    productTraversableToStatement[P, H, N, Stream[P]]
+
+  implicit def productVectorToStatement[P <: Product, H <: HList, N <: Nat](
+    implicit c: ToStatement[P], generic: Generic.Aux[P, H],
+    length: Length.Aux[H, N], toInt: ToInt[N]): ToStatement[Vector[P]] =
+    productTraversableToStatement[P, H, N, Vector[P]]
+
+  private implicit def productTraversableToStatement[P <: Product, H <: HList, N <: Nat, T <: Traversable[P]](
+    implicit c: ToStatement[P], generic: Generic.Aux[P, H],
+    length: Length.Aux[H, N], toInt: ToInt[N]): ToStatement[T] =
+    new ToStatement[T] with NotNullGuard {
+      def set(s: PreparedStatement, offset: Int, ps: T) =
         if (ps == null) throw new IllegalArgumentException()
         else ps.foldLeft(offset) { (i, p) => c.set(s, i, p); i + toInt.apply }
     }


### PR DESCRIPTION
As done also by Anorm itself I have extracted a generic private implicit conversion method replacing `List` with `Traversable`. Added multiple public implicit methods for `List`, `Seq`, `SortedSet`, `Stream` and `Vector`
